### PR TITLE
After death player stats fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -321,6 +321,8 @@ end
 
 function RemoveItemsAfterRPDeath()
 	TriggerServerEvent('esx_ambulancejob:setDeathStatus', false)
+				TriggerEvent('esx_status:set', 'hunger', 500000)
+				TriggerEvent('esx_status:set', 'thirst', 500000)		
 
 	Citizen.CreateThread(function()
 		DoScreenFadeOut(800)


### PR DESCRIPTION
Fixed bug when you die from hunger or thirst, and it would reappear with hunger = 0 and thirst = 0.